### PR TITLE
feat: replace english identifiers with spanish

### DIFF
--- a/client/scoreboard/src/app/core/realtime.ts
+++ b/client/scoreboard/src/app/core/realtime.ts
@@ -129,8 +129,8 @@ export class RealtimeService {
       .build();
 
     // Score
-    this.hub.on('scoreUpdated', (s: { homeScore: number; awayScore: number }) => {
-      this.score.set({ home: s.homeScore, away: s.awayScore });
+    this.hub.on('scoreUpdated', (p: { puntajeLocal: number; puntajeVisitante: number }) => {
+      this.score.set({ home: p.puntajeLocal, away: p.puntajeVisitante });
     });
 
     // Timer
@@ -168,8 +168,8 @@ export class RealtimeService {
     });
 
     // 👇 NUEVO: faltas en tiempo real
-    this.hub.on('foulsUpdated', (p: { homeFouls: number; awayFouls: number }) => {
-      this.fouls.set({ home: p.homeFouls, away: p.awayFouls });
+    this.hub.on('foulsUpdated', (p: { faltasLocal: number; faltasVisitante: number }) => {
+      this.fouls.set({ home: p.faltasLocal, away: p.faltasVisitante });
     });
 
     // Buzzer
@@ -189,3 +189,4 @@ export class RealtimeService {
     if (this.hub) { await this.hub.stop(); this.hub = undefined; }
   }
 }
+

--- a/client/scoreboard/src/app/features/control/control-panel/control-panel.html
+++ b/client/scoreboard/src/app/features/control/control-panel/control-panel.html
@@ -4,8 +4,8 @@
     <button class="btn ghost">Help</button>
     <button class="btn ghost">Options</button>
     <button class="btn" (click)="registerTeam()">Register Team</button>
-    <button class="btn" (click)="newGameFromRegistered()">New Game (Teams)</button>
-    <button class="btn ghost" (click)="newGame()">New Game (manual)</button>
+    <button class="btn" (click)="nuevoPartidoDesdeRegistrados()">New Game (Teams)</button>
+    <button class="btn ghost" (click)="nuevoPartido()">New Game (manual)</button>
     <button class="btn" (click)="showStandings()">Standings</button>
 
     <button class="btn">Correction</button>
@@ -45,7 +45,7 @@
     <div class="pos">
       <button class="btn pos-btn" [class.active]="possession() === 'home'" (click)="posLeft()">◄</button>
       <button class="btn pos-none" (click)="posNone()">
-        {{ possession() === 'none' ? 'None' : (possession() === 'home' ? homeName : awayName) }}
+        {{ possession() === 'none' ? 'None' : (possession() === 'home' ? nombreLocal : nombreVisitante) }}
       </button>
       <button class="btn pos-btn" [class.active]="possession() === 'away'" (click)="posRight()">►</button>
     </div>
@@ -74,49 +74,49 @@
   <div class="teams">
     <!-- HOME -->
     <div class="team">
-      <div class="name">{{ homeName }}</div>
+      <div class="name">{{ nombreLocal }}</div>
       <div class="sub">SCORE</div>
 
       <div class="score-row">
-        <button class="btn neg" [disabled]="!homeTeamId || !canScore()" (click)="minus1(homeTeamId)">-1</button>
-        <div class="score-display">{{ homeScore() }}</div>
-        <button class="btn pos" [disabled]="!homeTeamId || !canScore()" (click)="add(homeTeamId,1)">+1</button>
+        <button class="btn neg" [disabled]="!equipoLocalId || !canScore()" (click)="minus1(equipoLocalId)">-1</button>
+        <div class="score-display">{{ puntajeLocal() }}</div>
+        <button class="btn pos" [disabled]="!equipoLocalId || !canScore()" (click)="add(equipoLocalId,1)">+1</button>
       </div>
       <div class="score-actions">
-        <button class="btn pos" [disabled]="!homeTeamId || !canScore()" (click)="add(homeTeamId,3)">+3</button>
-        <button class="btn pos" [disabled]="!homeTeamId || !canScore()" (click)="add(homeTeamId,2)">+2</button>
+        <button class="btn pos" [disabled]="!equipoLocalId || !canScore()" (click)="add(equipoLocalId,3)">+3</button>
+        <button class="btn pos" [disabled]="!equipoLocalId || !canScore()" (click)="add(equipoLocalId,2)">+2</button>
       </div>
 
       <!-- FOULS HOME (horizontal) -->
       <div class="sub fouls-title">FOULS</div>
       <div class="fouls-row">
-        <button class="btn neg" [disabled]="!homeTeamId" (click)="foul(homeTeamId,-1)">-1</button>
-        <div class="fouls-display">{{ homeFouls() }}</div>
-        <button class="btn pos" [disabled]="!homeTeamId" (click)="foul(homeTeamId,1)">+1</button>
+        <button class="btn neg" [disabled]="!equipoLocalId" (click)="foul(equipoLocalId,-1)">-1</button>
+        <div class="fouls-display">{{ faltasLocal() }}</div>
+        <button class="btn pos" [disabled]="!equipoLocalId" (click)="foul(equipoLocalId,1)">+1</button>
       </div>
     </div>
 
     <!-- AWAY -->
     <div class="team">
-      <div class="name">{{ awayName }}</div>
+      <div class="name">{{ nombreVisitante }}</div>
       <div class="sub">SCORE</div>
 
       <div class="score-row">
-        <button class="btn neg" [disabled]="!awayTeamId || !canScore()" (click)="minus1(awayTeamId)">-1</button>
-        <div class="score-display">{{ awayScore() }}</div>
-        <button class="btn pos" [disabled]="!awayTeamId || !canScore()" (click)="add(awayTeamId,1)">+1</button>
+        <button class="btn neg" [disabled]="!equipoVisitanteId || !canScore()" (click)="minus1(equipoVisitanteId)">-1</button>
+        <div class="score-display">{{ puntajeVisitante() }}</div>
+        <button class="btn pos" [disabled]="!equipoVisitanteId || !canScore()" (click)="add(equipoVisitanteId,1)">+1</button>
       </div>
       <div class="score-actions">
-        <button class="btn pos" [disabled]="!awayTeamId || !canScore()" (click)="add(awayTeamId,3)">+3</button>
-        <button class="btn pos" [disabled]="!awayTeamId || !canScore()" (click)="add(awayTeamId,2)">+2</button>
+        <button class="btn pos" [disabled]="!equipoVisitanteId || !canScore()" (click)="add(equipoVisitanteId,3)">+3</button>
+        <button class="btn pos" [disabled]="!equipoVisitanteId || !canScore()" (click)="add(equipoVisitanteId,2)">+2</button>
       </div>
 
       <!-- FOULS AWAY (horizontal) -->
       <div class="sub fouls-title">FOULS</div>
       <div class="fouls-row">
-        <button class="btn neg" [disabled]="!awayTeamId" (click)="foul(awayTeamId,-1)">-1</button>
-        <div class="fouls-display">{{ awayFouls() }}</div>
-        <button class="btn pos" [disabled]="!awayTeamId" (click)="foul(awayTeamId,1)">+1</button>
+        <button class="btn neg" [disabled]="!equipoVisitanteId" (click)="foul(equipoVisitanteId,-1)">-1</button>
+        <div class="fouls-display">{{ faltasVisitante() }}</div>
+        <button class="btn pos" [disabled]="!equipoVisitanteId" (click)="foul(equipoVisitanteId,1)">+1</button>
       </div>
     </div>
   </div>

--- a/client/scoreboard/src/app/features/control/control-panel/control-panel.ts
+++ b/client/scoreboard/src/app/features/control/control-panel/control-panel.ts
@@ -179,19 +179,19 @@ export class ControlPanelComponent implements OnDestroy {
   }
 
   // === Puntos
-  add(teamId: number | undefined, points: 1 | 2 | 3) {
-    if (!teamId || !this.canScore()) return;
-    this.api.crearPuntaje(this.matchId(), { teamId, points }).subscribe();
+  add(equipoId: number | undefined, puntos: 1 | 2 | 3) {
+    if (!equipoId || !this.canScore()) return;
+    this.api.crearPuntaje(this.matchId(), { equipoId, puntos }).subscribe();
   }
-  minus1(teamId: number | undefined) {
-    if (!teamId || !this.canScore()) return;
-    this.api.ajustarPuntaje(this.matchId(), { teamId, delta: -1 }).subscribe();
+  minus1(equipoId: number | undefined) {
+    if (!equipoId || !this.canScore()) return;
+    this.api.ajustarPuntaje(this.matchId(), { equipoId, delta: -1 }).subscribe();
   }
 
   // === Faltas
-  foul(teamId: number | undefined, delta: 1 | -1) {
-    if (!teamId) return;
-    this.api.ajustarFalta(this.matchId(), { teamId, delta }).subscribe();
+  foul(equipoId: number | undefined, delta: 1 | -1) {
+    if (!equipoId) return;
+    this.api.ajustarFalta(this.matchId(), { equipoId, delta }).subscribe();
   }
 
   // === Timer
@@ -260,7 +260,7 @@ export class ControlPanelComponent implements OnDestroy {
     });
     ref.afterClosed().subscribe(result => {
       if (!result) return;
-      this.api.createTeam(result).subscribe({
+      this.api.crearEquipo(result).subscribe({
         next: async (res: any) => {
           await Swal.fire({
             icon: 'success',
@@ -268,7 +268,7 @@ export class ControlPanelComponent implements OnDestroy {
             timer: 1200, showConfirmButton: false, position: 'top'
           });
         },
-        error: async (e) => {
+        error: async (e: any) => {
           await Swal.fire({ icon: 'error', title: 'Error creating team', text: e?.error ?? e?.message ?? 'Unknown error' });
         }
       });
@@ -312,14 +312,14 @@ export class ControlPanelComponent implements OnDestroy {
   }
 
   showStandings() {
-    this.api.getStandings().subscribe({
-      next: (rows) => {
+    this.api.obtenerPosiciones().subscribe({
+      next: (rows: any) => {
         this.dialog.open(StandingsDialogComponent, {
           width: '520px',
           data: { rows }
         });
       },
-      error: (e) => {
+      error: (e: any) => {
         console.error('getStandings error', e);
         // Si usas SweetAlert:
         // Swal.fire({ icon: 'error', title: 'Error cargando standings', text: e?.error ?? e?.message ?? 'Unknown error' });

--- a/client/scoreboard/src/app/features/scoreboard/scoreboard/scoreboard.html
+++ b/client/scoreboard/src/app/features/scoreboard/scoreboard/scoreboard.html
@@ -17,7 +17,7 @@
   <!-- MIDDLE: SCORE - POS/PERIOD - SCORE -->
   <div class="middle">
     <div class="score-box left">
-      <app-team-panel [label]="homeName" [score]="realtime.score().home"></app-team-panel>
+      <app-team-panel [label]="nombreLocal" [score]="realtime.score().home"></app-team-panel>
     </div>
 
     <div class="center">
@@ -30,7 +30,8 @@
     </div>
 
     <div class="score-box right">
-      <app-team-panel [label]="awayName" [score]="realtime.score().away"></app-team-panel>
+      <app-team-panel [label]="nombreVisitante" [score]="realtime.score().away"></app-team-panel>
     </div>
   </div>
 </div>
+

--- a/client/scoreboard/src/app/features/scoreboard/scoreboard/scoreboard.ts
+++ b/client/scoreboard/src/app/features/scoreboard/scoreboard/scoreboard.ts
@@ -25,8 +25,8 @@ export class ScoreboardComponent {
 
   matchId = computed(() => Number(this.route.snapshot.paramMap.get('id') ?? '1'));
 
-  homeName = 'A TEAM';
-  awayName = 'B TEAM';
+  nombreLocal = 'A TEAM';
+  nombreVisitante = 'B TEAM';
 
   constructor() {
     effect(() => {
@@ -35,8 +35,8 @@ export class ScoreboardComponent {
       const text = over.winner === 'draw'
         ? `Empate ${over.home} - ${over.away}`
         : over.winner === 'home'
-          ? `¡Ganó ${this.homeName}! ${over.home} - ${over.away}`
-          : `¡Ganó ${this.awayName}! ${over.away} - ${over.home}`;
+          ? `¡Ganó ${this.nombreLocal}! ${over.home} - ${over.away}`
+          : `¡Ganó ${this.nombreVisitante}! ${over.away} - ${over.home}`;
       Swal.fire({ title: 'Fin del partido', text, icon: 'warning', position: 'top', showConfirmButton: true });
     });
   }
@@ -45,8 +45,8 @@ export class ScoreboardComponent {
     this.api.obtenerPartido(this.matchId()).subscribe({
       next: (m: any) => {
         this.realtime.score.set({ home: m.puntajeLocal, away: m.puntajeVisitante });
-        this.homeName = m.equipoLocal || 'A TEAM';
-        this.awayName = m.equipoVisitante || 'B TEAM';
+        this.nombreLocal = m.equipoLocal || 'A TEAM';
+        this.nombreVisitante = m.equipoVisitante || 'B TEAM';
         this.realtime.hydrateTimerFromSnapshot(m.timer);
         this.realtime.hydrateFoulsFromSnapshot({ home: m.faltasLocal, away: m.faltasVisitante });
       }
@@ -62,3 +62,4 @@ export class ScoreboardComponent {
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- use nuevoPartidoDesdeRegistrados and nuevoPartido in control panel template
- rename team and score bindings to nombreLocal/puntajeLocal and nombreVisitante/puntajeVisitante
- update API calls and realtime service to use Spanish field names

## Testing
- `npm test` *(fails: Module './app' has no exported member 'App')*

------
https://chatgpt.com/codex/tasks/task_e_68a8cce0a4088324974fd86ca5dcb391