### PR TITLE
fix: configure api base URL

### DIFF
--- a/client/scoreboard/src/app/core/api.ts
+++ b/client/scoreboard/src/app/core/api.ts
@@ -1,10 +1,11 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../enviroments/enviroments';
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
   private http = inject(HttpClient);
-  private base = '/api';
+  private base = environment.apiBaseUrl;
 
   obtenerPartido(id: number) {
     return this.http.get<any>(`${this.base}/partidos/${id}`);
@@ -53,7 +54,7 @@ export class ApiService {
     );
   }
   crearEquipo(body: { nombre: string; color?: string; jugadores: { numero?: number; nombre: string }[] }) {
-    return this.http.post('/api/equipos', body);
+    return this.http.post(`${this.base}/equipos`, body);
   }
 
   obtenerPosiciones() {

--- a/client/scoreboard/src/enviroments/enviroments.ts
+++ b/client/scoreboard/src/enviroments/enviroments.ts
@@ -1,6 +1,6 @@
 // environment.ts / environment.prod.ts
 export const environment = {
   production: true,
-  apiBaseUrl: '/api',
-  hubUrl: '/hubs/score'
+  apiBaseUrl: 'http://localhost:8080/api',
+  hubUrl: 'http://localhost:8080/hubs/score'
 };


### PR DESCRIPTION
## Summary
- point Angular environment to .NET backend
- use environment base URL for API service requests
- fix backend port to 8080 for API and SignalR hub

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: TS2305 module './app' has no exported member 'App')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d5b3112083248eecb94113992e65